### PR TITLE
Bugfix the GitHub Action deploy with cname

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,3 +33,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages  # deploying branch
+          cname: afun.tw


### PR DESCRIPTION
Considering the CI progress required to deploy with CNAME, refer to https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-add-cname-file-cname